### PR TITLE
Work in progess multimonitor support for background mode

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ sources = [ './src/main.c', './src/shader.c', './src/arghandler.c' ]
 deps  = [ dependency('imlib2') ]
 deps += [ dependency('GLEW'),dependency('GL') ]
 deps += [ dependency('X11') ]
+deps += [ dependency('xrandr') ]
 deps += [ cc.find_library('m') ]
 
 executable('show', sources, dependencies: deps, install: true )


### PR DESCRIPTION
Moved shader and window into `Renderer` struct, which in the future will additionally store models and textures. By specifying `--display <display>` the window will spawn at `x` `y` width `screenwidth` and `screenheight`. Additional work is needed in `arghandler` to spawn multiple background windows with different shaders. Root mode currently also doesn't work with `--display`