### PR TITLE
Fixed windows 11 not in background

### DIFF
--- a/shadow/shadow.py
+++ b/shadow/shadow.py
@@ -318,7 +318,7 @@ class ShadowWin10(Shadow):
 
         # Set created window as child of workerw
         hwnd = glfw.get_win32_window(self.window)
-        user32.SetParent(hwnd, self.workerw)
+        user32.SetParent(hwnd, self.workerw if self.workerw else progman_hwnd)
 
         # Hide window icon
         GWL_EXSTYLE=-20


### PR DESCRIPTION
On windows 11 the "win10" mode didn't put the window into the background.